### PR TITLE
Use cross-spawn when spawning

### DIFF
--- a/lib/plugins/spawn/index.js
+++ b/lib/plugins/spawn/index.js
@@ -3,6 +3,7 @@ var stderr = require('./stderr');
 var psr = require('parse-service-request');
 var crypto = require('crypto');
 var path = require('path');
+var spawn = require('cross-spawn');
 
 // Remark: tree-kill is important as it's possible microservices may spawn child processes 
 // ( which must be killed in order to prevent zombie process / orphaned process )
@@ -221,8 +222,6 @@ module['exports'] = function spawnService (service) {
       // opts.env - custom environment variables / methods to inject into service handler ( defaults to {} )
 
       __env.hookAccessKey = input.env.hookAccessKey;
-
-      var spawn = require('child_process').spawn;
 
       var vm;
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "async": "^2.0.1",
+    "cross-spawn": "^5.0.0",
     "hyperquest": "^2.0.0",
     "merge-params": "^1.1.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
This uses `cross-spawn` instead of vanilla `child_process` for spawning new processes.