### PR TITLE
Added Java support

### DIFF
--- a/bin/binaries/micro-java
+++ b/bin/binaries/micro-java
@@ -1,0 +1,12 @@
+#!/bin/bash
+_CODE=$2
+_INJECT=$6
+
+# Detect java
+_java=$(readlink -f $(which java))
+
+# End Detect java
+source_name=$(basename "$_CODE")
+class_name=${source_name%%.*}
+dir_name=$(dirname "$_CODE")
+cd "$dir_name"; echo `$_java $class_name`

--- a/examples/services/echo/echo.java
+++ b/examples/services/echo/echo.java
@@ -1,0 +1,7 @@
+class echo
+{
+        public static void main(String args[])
+        {
+           System.out.println("Hello World!");
+        }
+}

--- a/lib/plugins/spawn/compileServiceCode/java/index.js
+++ b/lib/plugins/spawn/compileServiceCode/java/index.js
@@ -1,0 +1,30 @@
+var tmp = require('tmp');
+var path = require('path');
+var fs = require("fs");
+var spawnSync = require('child_process').spawnSync;
+
+function getClassNameFromSource(code) {
+  const regex = /class\s+(.*)/g;
+  var match = regex.exec(code);
+  return match[1];
+}
+
+function compileJavaSource(sourcePath) {
+  var opts = {};
+  var javac = spawnSync('javac', [sourcePath], opts);
+}
+
+module['exports'] = function compileJava (code, cb) {
+  // Move code to a temporary location
+  var tmpDir = tmp.dirSync().name;
+  var className = getClassNameFromSource(code);
+  var bytecodePath = path.join(tmpDir, className + ".class");
+  var sourcePath = path.join(tmpDir, className + ".java");
+  fs.writeFileSync(sourcePath, code);
+
+  // Now compile the java file
+  compileJavaSource(sourcePath);
+  console.log(bytecodePath);
+  // Return the bytecode path instead of source. We can point the JVM to this path and it will run.
+  return bytecodePath;
+}

--- a/lib/plugins/spawn/generateCommandLineArguments/java/index.js
+++ b/lib/plugins/spawn/generateCommandLineArguments/java/index.js
@@ -1,0 +1,43 @@
+function bashEscape (arg) {
+  if (typeof arg === "undefined") {
+    return "";
+  }
+  var str;
+  str = arg.toString();
+  /*
+  if (typeof arg === "object") {
+    str = JSON.stringify(arg);
+  } else {
+  }
+  */
+  str = arg.toString().replace(/"/g, '\'');
+  str = str.split("\r\n");
+  str = str.join(" ");
+  return str;
+}
+
+module['exports'] = function generateJavaArguments (service, env) {
+
+  // parsing JSON in bash is not so great
+  // instead, just iterate through all our properties,
+  // and generate a bunch of unique keys
+  var args = [];
+  var bashInject = "";
+  bashInject += 'Hook="The Hook object isnt a bash object.";\n'
+  bashInject += 'Hook_params="The Hook.params object isnt a bash object.";\n'
+  for (var p in env) {
+    if (typeof env[p] === "object") {
+      for (var s in env[p]) {
+        bashInject += 'Hook_' + p + '_' + s + '="' + bashEscape(env[p][s]) + '";\n'
+      }
+    } else {
+      bashInject += 'Hook_' + p + '="' + bashEscape(env[p]) + '";\n'
+    }
+  }
+  args = [
+    '-code', service.code,
+    '-service', JSON.stringify(service),
+    '-payload', bashInject
+  ];
+  return args;
+}

--- a/lib/plugins/spawn/index.js
+++ b/lib/plugins/spawn/index.js
@@ -5,7 +5,7 @@ var crypto = require('crypto');
 var path = require('path');
 var spawn = require('cross-spawn');
 
-// Remark: tree-kill is important as it's possible microservices may spawn child processes 
+// Remark: tree-kill is important as it's possible microservices may spawn child processes
 // ( which must be killed in order to prevent zombie process / orphaned process )
 var kill = require('tree-kill');
 
@@ -18,6 +18,7 @@ var generateArguments = {
   ocaml: require('./generateCommandLineArguments/ocaml'),
   perl: require('./generateCommandLineArguments/perl'),
   scheme: require('./generateCommandLineArguments/scheme'),
+  java: require('./generateCommandLineArguments/java'),
   smalltalk: require('./generateCommandLineArguments/smalltalk'),
   tcl: require('./generateCommandLineArguments/tcl')
 };
@@ -25,7 +26,8 @@ var generateArguments = {
 var compileService = {
   "coffee": require('./compileServiceCode/coffee-script'),
   "coffee-script": require('./compileServiceCode/coffee-script'),
-  "babel": require('./compileServiceCode/babel')
+  "babel": require('./compileServiceCode/babel'),
+  "java": require('./compileServiceCode/java')
 };
 
 // Remark: This is the local compile cache
@@ -138,7 +140,7 @@ module['exports'] = function spawnService (service) {
       /*
          Possible results of spawnService
 
-           Remark: These are to be used as a reference and are possibly not complete / correct. 
+           Remark: These are to be used as a reference and are possibly not complete / correct.
                    These cases will most likely develop these into unit tests
 
            vm opens -> service calls res.end -> vm closes -> response
@@ -237,6 +239,7 @@ module['exports'] = function spawnService (service) {
         "es7": "micro-node", // legacy name, renamed to "babel"
         "lua": "micro-lua",
         "javascript": "micro-node",
+        "java": "micro-java",
         "ocaml": "micro-ocaml",
         "perl": "micro-perl",
         "php": "micro-php",
@@ -419,7 +422,7 @@ module['exports'] = function spawnService (service) {
 
       }
     }
- 
+
   };
 
 };

--- a/lib/requireServiceSync.js
+++ b/lib/requireServiceSync.js
@@ -3,7 +3,7 @@ var fs = require('fs'),
 
 function extToLang (ext) {
   var lang;
-  
+
   return lang;
 }
 
@@ -91,6 +91,7 @@ function loadService (p, type) {
     ".ml": "ocaml",
     ".php": "php",
     ".pl": "perl",
+    ".java": "java",
     ".py": "python", // Remark: You can also use the "--language python" option
     ".py3": "python3", // Remark: You can also use the "--language python3" option
     ".sh": "bash",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "run-service": "2.x.x",
     "stream-buffers": "^3.0.1",
     "through2": "^2.0.1",
+    "tmp": "0.0.31",
     "tree-kill": "^1.1.0",
     "view": "1.0.0"
   },

--- a/test/all-languages-tests.js
+++ b/test/all-languages-tests.js
@@ -9,7 +9,7 @@ microcule = require('../');
 
 // Remark: babel and coffee-script are commented out since they aren't included in the package
 // Even as devDependencies they are too big
-var languages = ['bash', /* 'babel', 'coffee-script', */ 'smalltalk', 'lua', 'javascript', 'perl', 'php', 'python', 'python3', 'ruby', 'scheme', 'tcl'];
+var languages = ['bash', /* 'babel', 'coffee-script', */ 'smalltalk', 'lua', 'javascript', 'perl', 'php', 'python', 'python3', 'ruby', 'scheme', 'tcl', 'java'];
 
 test('attempt to require microservice-examples module', function (t) {
   examples = require('microservice-examples');


### PR DESCRIPTION
Hi Microcule devs,

I've began adding Java to Microcule use your awesome tool on the JVM :+1: .
It's probably not ready yet, as streaming isn't tested and tests are yet to be written (in microcule-examples)

I just wanted to post this pull request in advance, so you can evaluate and give feedback on my work. So far, it's been a great experience to work in your code. Have a nice day!

Details of what it's doing:

 - run `./bin/microcule ./helloworld.java`  from source (create the said java file)
 - it detects files with .java extension
 - compiles down to .class in a temporary file
 - sends the class path as compiled source to micro-java (JVM can't run source directly, so a path was needed)
 - runs the code and shows the output in the reply.

TODO:

 - Add support for (JSON?) parameters
 - Add tests
 - Support for other JVM languages like Kotlin